### PR TITLE
ADD: update and delete endpoints for cart_table and cart_item_table

### DIFF
--- a/backend/cart/model.py
+++ b/backend/cart/model.py
@@ -31,11 +31,10 @@ class Cart(db.Model):
     title: Mapped[str] = mapped_column()
     description: Mapped[str | None] = mapped_column()
     date_created: Mapped[datetime.datetime] = mapped_column()
-    cart_items: Mapped[List["Cart_Item"] | None] = relationship(cascade="all, delete")  
+    cart_items: Mapped[List["Cart_Item"] | None] = relationship(cascade="all, delete, delete-orphan")  
+    # If the user is unregistered, creator will be set to null
     creator: Mapped[str | None] = mapped_column(ForeignKey("user_table.id"))# "User" | None is equivalent to Optional["User"] indicating nullable field
-        # TODO: does this need back_population? 
-        # TODO: do we want unregistered users to be able to make carts?
-    # users: Mapped[List[String] | None] = mapped_column() # users who can edit metadata 
+    users: Mapped[str| None] = mapped_column() # users who can edit metadata, stored in the format "{id},{id},{id}" and so on
 
 
 

--- a/backend/cart/views.py
+++ b/backend/cart/views.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, Blueprint, jsonify, Response
-from sqlalchemy import insert, select
+from sqlalchemy import insert, select, update, delete
 from backend import db
 from ..cart.model import Cart
 from datetime import datetime, timezone
@@ -10,7 +10,7 @@ bp = Blueprint("cart", __name__)
 
 """
 TODO: 
-- get, post, update, delete
+- update, delete
 """
 
 def get_time_now():
@@ -24,7 +24,8 @@ def create_cart():
         title=data.get("title", None),
         description=data.get("description", None),
         date_created=get_time_now(),
-        creator=data.get("creator", None)
+        creator=data.get("creator", None),
+        users=""
         ))
     db.session.commit()
     return jsonify({"id": cart.inserted_primary_key[0]}) # https://docs.sqlalchemy.org/en/20/tutorial/data_insert.html#the-insert-sql-expression-construct
@@ -38,7 +39,8 @@ def get_all_carts():
                 "description": c.description,
                 "date_created": c.date_created,
                 # "cart_items": c.cart_items, # if you want to see the cart items, currently only way is to query again by id
-                "creator": c.creator
+                "creator": c.creator,
+                "users": c.users
         } for c in carts])
 
 @bp.route("/<cart_id>", methods=["GET"])
@@ -56,8 +58,63 @@ def get_cart_by_id(cart_id):
                 "description": cart.description,
                 "date_created": cart.date_created,
                 "cart_items": cart_items,
-                "creator": cart.creator
+                "creator": cart.creator,
+                "users": cart.users
            })
+
+@bp.route("/<cart_id>", methods=["PUT"])
+def update_cart_by_id(cart_id):
+    data = request.json
+
+    cart = db.session.scalars(select(Cart).where(Cart.id == cart_id)).one()
+    query = update(Cart).\
+            where(Cart.id == cart_id).\
+            values(
+                title=data.get("title", cart.title),
+                description=data.get("description", cart.description)
+            ).\
+            returning(Cart.id)
+    cart = db.session.execute(query)
+    db.session.commit()
+    return jsonify({"id": cart.fetchone()[0]})
+
+@bp.route("/<cart_id>", methods=["DELETE"])
+def delete_cart_by_id(cart_id):
+    query = delete(Cart).where(Cart.id == cart_id)
+    db.session.execute(query)
+    db.session.commit()
+    return f"Deleted {cart_id}"
+    # items = cart.cart_items
+    # cart_items = [{
+    #     "id": item.id,
+    #     "item_name": item.item_name,
+    #     "quantity": item.quantity
+    # } for item in items]
+    # return jsonify({
+    #             "id": cart.id,
+    #             "title": cart.title,
+    #             "description": cart.description,
+    #             "date_created": cart.date_created,
+    #             "cart_items": cart_items,
+    #             "creator": cart.creator,
+    #             "users": cart.users
+    #        })
+
+@bp.route("/", methods=["DELETE"])
+def delete_all_carts():
+    query = delete(Cart)
+    db.session.execute(query)
+    db.session.commit()
+    return "Deleted all carts"
+    # return jsonify([{"count": len(carts)}] + [{
+    #             "id": c.id,
+    #             "title": c.title,
+    #             "description": c.description,
+    #             "date_created": c.date_created,
+    #             # "cart_items": c.cart_items, # if you want to see the cart items, currently only way is to query again by id
+    #             "creator": c.creator,
+    #             "users": c.users
+    #     } for c in carts])
 
 
 

--- a/backend/cart_item/model.py
+++ b/backend/cart_item/model.py
@@ -15,7 +15,8 @@ class Cart_Item(db.Model):
     __tablename__ = "cart_item_table"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    cart_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("cart_table.id"))
+    cart_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("cart_table.id", ondelete='CASCADE'))
+    cart: Mapped["Cart"] = relationship() # NOTE: I guess if you have a foreign key you must also have a field that holds the foreign object?
     item_name: Mapped[str] = mapped_column()
     quantity: Mapped[int] = mapped_column()
 


### PR DESCRIPTION
Added update by id, delete by id, and delete all endpoints for cart and cart_item. Got `ON DELETE cascade` to work for cart_table rows (deleting a cart row will delete all related cart_item rows). 